### PR TITLE
fix(phone_mcp): handle screenshot capture in get_screen_info

### DIFF
--- a/phone_mcp/tools/screen_interface.py
+++ b/phone_mcp/tools/screen_interface.py
@@ -16,7 +16,6 @@ from .ui_enhanced import (
     find_clickable_elements, wait_for_element, scroll_to_element
 )
 from .interactions import tap_screen, swipe_screen, press_key, input_text, get_screen_size
-from .media import take_screenshot
 from ..core import run_command
 
 logger = logging.getLogger("phone_mcp")
@@ -194,9 +193,11 @@ async def get_screen_info(include_screenshot: bool = True, max_elements: int = 1
         # Take a screenshot for reference if needed
         screenshot_base64 = ""
         if include_screenshot:
-            screenshot_result = await take_screenshot()
-            screenshot_data = json.loads(screenshot_result)
-            screenshot_base64 = screenshot_data.get("data", "") if screenshot_data.get("status") == "success" else ""
+            # take_screenshot() returns a human-readable status string, not JSON,
+            # so capture and encode the screenshot directly instead.
+            b64_success, b64_output = await run_command("adb exec-out screencap -p | base64")
+            if b64_success:
+                screenshot_base64 = b64_output.replace("\n", "").replace("\r", "")
         
         # Build result
         result = {
@@ -455,7 +456,10 @@ async def analyze_screen(include_screenshot: bool = False, max_elements: int = 5
             },
             "suggested_actions": suggested_actions,
         }
-        
+
+        if include_screenshot:
+            screen_analysis["screenshot"] = screen_info.get("screenshot", "")
+
         return json.dumps(screen_analysis, ensure_ascii=False)
         
     except Exception as e:

--- a/tests/test_screen_interface.py
+++ b/tests/test_screen_interface.py
@@ -1,0 +1,88 @@
+import json
+import pytest
+from unittest.mock import patch, AsyncMock
+
+from phone_mcp.tools.screen_interface import get_screen_info, analyze_screen
+
+
+EMPTY_UI_DUMP = json.dumps({"status": "success", "elements": []})
+SCREEN_SIZE = json.dumps({"width": 1080, "height": 1920})
+NO_CLICKABLES = json.dumps({"status": "success", "elements": []})
+
+
+@pytest.mark.asyncio
+class TestGetScreenInfoScreenshot:
+    """Regression tests for include_screenshot=True.
+
+    get_screen_info() used to call take_screenshot() and json.loads() its
+    result, but take_screenshot() returns a plain human-readable status
+    string rather than JSON, so this always raised JSONDecodeError and was
+    swallowed into a generic "Failed to get screen information" error.
+    """
+
+    async def _mocks(self):
+        return (
+            patch(
+                "phone_mcp.tools.screen_interface.dump_ui",
+                new_callable=AsyncMock,
+                return_value=EMPTY_UI_DUMP,
+            ),
+            patch(
+                "phone_mcp.tools.screen_interface.get_screen_size",
+                new_callable=AsyncMock,
+                return_value=SCREEN_SIZE,
+            ),
+            patch(
+                "phone_mcp.tools.screen_interface.find_clickable_elements",
+                new_callable=AsyncMock,
+                return_value=NO_CLICKABLES,
+            ),
+        )
+
+    async def test_include_screenshot_true_returns_base64_png(self):
+        dump_ui_p, size_p, clickable_p = await self._mocks()
+        with dump_ui_p, size_p, clickable_p, patch(
+            "phone_mcp.tools.screen_interface.run_command", new_callable=AsyncMock
+        ) as run_command_mock:
+            run_command_mock.return_value = (True, "iVBORw0KGgoAAAANSUhEUg==\n")
+
+            result = json.loads(await get_screen_info(include_screenshot=True))
+
+        assert result["status"] == "success"
+        assert result["screenshot"] == "iVBORw0KGgoAAAANSUhEUg=="
+        run_command_mock.assert_awaited_once_with("adb exec-out screencap -p | base64")
+
+    async def test_include_screenshot_false_skips_capture(self):
+        dump_ui_p, size_p, clickable_p = await self._mocks()
+        with dump_ui_p, size_p, clickable_p, patch(
+            "phone_mcp.tools.screen_interface.run_command", new_callable=AsyncMock
+        ) as run_command_mock:
+            result = json.loads(await get_screen_info(include_screenshot=False))
+
+        assert result["status"] == "success"
+        assert "screenshot" not in result
+        run_command_mock.assert_not_awaited()
+
+    async def test_include_screenshot_capture_failure_yields_empty_string(self):
+        dump_ui_p, size_p, clickable_p = await self._mocks()
+        with dump_ui_p, size_p, clickable_p, patch(
+            "phone_mcp.tools.screen_interface.run_command", new_callable=AsyncMock
+        ) as run_command_mock:
+            run_command_mock.return_value = (False, "error: no devices/emulators found")
+
+            result = json.loads(await get_screen_info(include_screenshot=True))
+
+        assert result["status"] == "success"
+        assert result["screenshot"] == ""
+
+    async def test_analyze_screen_include_screenshot_true(self):
+        dump_ui_p, size_p, clickable_p = await self._mocks()
+        with dump_ui_p, size_p, clickable_p, patch(
+            "phone_mcp.tools.screen_interface.run_command", new_callable=AsyncMock
+        ) as run_command_mock:
+            run_command_mock.return_value = (True, "iVBORw0KGgoAAAANSUhEUg==\n")
+
+            result = json.loads(await analyze_screen(include_screenshot=True))
+
+        assert result["status"] == "success"
+        assert result["screenshot"] == "iVBORw0KGgoAAAANSUhEUg=="


### PR DESCRIPTION
Fixes #11

## Summary

`get_screen_info(include_screenshot=True)` (and therefore `analyze_screen(include_screenshot=True)`) always crashed with:

```json
{"status": "error", "message": "Failed to get screen information: Expecting value: line 1 column 1 (char 0)"}
```

- `get_screen_info()` called `take_screenshot()` and then `json.loads()` on its return value, but `take_screenshot()` returns a plain human-readable status string (e.g. `"Screenshot taken and saved to device (...) and pulled to current directory (...)"`), never JSON — so `json.loads()` always raised `JSONDecodeError`.
- Fixed by capturing and base64-encoding the screenshot directly via `adb exec-out screencap -p | base64` instead of relying on `take_screenshot()`'s text output.
- While fixing this, found and fixed a second related bug: `analyze_screen()`'s docstring promises a `screenshot` key in its output when `include_screenshot=True`, but the code never copied it from `get_screen_info()`'s result into the final response dict, so it was silently dropped even after the crash above is fixed.
- Added `tests/test_screen_interface.py` covering `get_screen_info`/`analyze_screen` with `include_screenshot` True/False and capture-failure scenarios.

## Test plan

- [x] Verified against a real connected device: `analyze_screen(include_screenshot=True)` now returns `status: success` with a valid base64-encoded PNG (`iVBORw0KGgo...` prefix).
- [x] `python3 -m pytest tests/test_screen_interface.py -q` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)